### PR TITLE
Fix maxItems before pokemon data loads

### DIFF
--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -33,7 +33,7 @@ export const Home = () => {
         perPage={perPage}
         nextPage={nextPage}
         previousPage={previousPage}
-        maxItems={pokemonsFiltered?.length!}
+        maxItems={pokemonsFiltered?.length ?? 0}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- handle undefined Pokemon list count in pagination

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module ...)*

------
https://chatgpt.com/codex/tasks/task_e_6840c22e010883258dbe26641bed0683