### PR TITLE
Add basic Team Builder feature

### DIFF
--- a/src/components/PokemonDetail/index.tsx
+++ b/src/components/PokemonDetail/index.tsx
@@ -1,6 +1,8 @@
 import { IPokemon } from "../../interfaces/interfaces";
 import { background } from "../../utils/BackgroundsByType";
 import { Loader } from "../Loader";
+import { useContext } from "react";
+import { TeamContext } from "../../context/TeamContext";
 import { BaseStats } from "./components/BaseStats";
 import { Header } from "./components/Header";
 import { PokeTypes } from "./components/PokeTypes";
@@ -16,6 +18,10 @@ interface Props {
 export const PokemonDetail = ({ pokemon }: Props) => {
   /* @ts-ignore */
   const backgroundSelected = background[pokemon?.types[0]?.type?.name];
+  const { team, addPokemon, removePokemon } = useContext(TeamContext);
+
+  const url = `https://pokeapi.co/api/v2/pokemon/${pokemon?.id}`;
+  const inTeam = team.includes(url);
 
   if (!pokemon) {
     return (
@@ -40,6 +46,12 @@ export const PokemonDetail = ({ pokemon }: Props) => {
           alt={pokemon?.name}
         />
         <PokeTypes pokemon={pokemon} />
+        <button
+          className={styles.teamButton}
+          onClick={() => (inTeam ? removePokemon(url) : addPokemon(url))}
+        >
+          {inTeam ? "Quitar del equipo" : "Agregar al equipo"}
+        </button>
         <Title content="About" backgroundSelected={backgroundSelected} />
         <Stats pokemon={pokemon} />
         <Title content="Base Stats" backgroundSelected={backgroundSelected} />

--- a/src/components/PokemonDetail/styles.module.scss
+++ b/src/components/PokemonDetail/styles.module.scss
@@ -27,6 +27,15 @@
       height: 275px;
       object-fit: contain;
     }
+
+    .teamButton {
+      margin-top: 1rem;
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 4px;
+      background: #e0e0e0;
+      cursor: pointer;
+    }
   }
 }
 

--- a/src/components/TeamPokemonCard/index.tsx
+++ b/src/components/TeamPokemonCard/index.tsx
@@ -1,0 +1,59 @@
+import { useContext } from "react";
+import { Link } from "react-router-dom";
+import { usePokemon } from "../../hooks/usePokemon";
+import { background } from "../../utils/BackgroundsByType";
+import { TeamContext } from "../../context/TeamContext";
+import { Loader } from "../Loader";
+
+import styles from "./styles.module.scss";
+
+interface Props {
+  url: string;
+}
+
+export const TeamPokemonCard = ({ url }: Props) => {
+  const { pokemon } = usePokemon(url);
+  const { removePokemon } = useContext(TeamContext);
+
+  /* @ts-ignore */
+  const backgroundSelected = background[pokemon?.types[0]?.type?.name];
+
+  return (
+    <div className={styles.wrapper}>
+      <Link to={`/${pokemon?.id}`} className={styles.pokeCard}>
+        <div
+          style={{ borderColor: backgroundSelected }}
+          className={styles.top}
+        >
+          <span style={{ color: backgroundSelected }}>#{pokemon?.id}</span>
+          {pokemon?.sprites?.other?.dream_world?.front_default ||
+          pokemon?.sprites?.front_default ? (
+            <img
+              src={
+                pokemon?.sprites?.other?.dream_world?.front_default ||
+                pokemon?.sprites?.front_default
+              }
+              alt={pokemon?.name}
+            />
+          ) : (
+            <div className={styles.loadingContainer}>
+              <Loader color={backgroundSelected} />
+            </div>
+          )}
+        </div>
+        <div
+          style={{ background: backgroundSelected }}
+          className={styles.bottom}
+        >
+          {pokemon?.name}
+        </div>
+      </Link>
+      <button
+        className={styles.remove}
+        onClick={() => removePokemon(url)}
+      >
+        X
+      </button>
+    </div>
+  );
+};

--- a/src/components/TeamPokemonCard/styles.module.scss
+++ b/src/components/TeamPokemonCard/styles.module.scss
@@ -1,0 +1,67 @@
+.wrapper {
+  position: relative;
+  width: 100%;
+  max-width: 350px;
+}
+
+.pokeCard {
+  width: 100%;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: inherit;
+
+  .top {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid transparent;
+    border-start-start-radius: 8px;
+    border-start-end-radius: 8px;
+    border-bottom: none;
+
+    span {
+      text-align: end;
+      padding: 4px 8px 0px;
+    }
+
+    img {
+      width: 90%;
+      height: 140px;
+      object-fit: contain;
+      align-self: center;
+      padding: 0.5rem 1rem;
+    }
+
+    .loadingContainer {
+      height: 140px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  }
+
+  .bottom {
+    font-size: 16px;
+    line-height: 16px;
+    padding: 1rem;
+    border-end-start-radius: 8px;
+    border-end-end-radius: 8px;
+    text-align: center;
+    text-transform: capitalize;
+    color: white;
+  }
+}
+
+.remove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: #ff6b6b;
+  border: none;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  color: white;
+  cursor: pointer;
+}

--- a/src/context/TeamContext.tsx
+++ b/src/context/TeamContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useEffect, useState } from "react";
+
+interface ContextProps {
+  team: string[];
+  addPokemon: (url: string) => void;
+  removePokemon: (url: string) => void;
+}
+
+export const TeamContext = createContext<ContextProps>({} as ContextProps);
+
+const TeamProvider = ({ children }: any) => {
+  const [team, setTeam] = useState<string[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("team");
+    if (stored) {
+      try {
+        setTeam(JSON.parse(stored));
+      } catch {
+        setTeam([]);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("team", JSON.stringify(team));
+  }, [team]);
+
+  const addPokemon = (url: string) => {
+    setTeam((prev) => {
+      if (prev.includes(url) || prev.length >= 6) return prev;
+      return [...prev, url];
+    });
+  };
+
+  const removePokemon = (url: string) => {
+    setTeam((prev) => prev.filter((p) => p !== url));
+  };
+
+  return (
+    <TeamContext.Provider value={{ team, addPokemon, removePokemon }}>
+      {children}
+    </TeamContext.Provider>
+  );
+};
+
+export default TeamProvider;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,11 @@
 import ReactDOM from "react-dom/client";
 
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import { Home, PokeDetail } from "./pages";
+import { Home, PokeDetail, Team } from "./pages";
 
 import "./index.scss";
 import PokemonProvider from "./context/PokemonContext";
+import TeamProvider from "./context/TeamContext";
 
 const router = createBrowserRouter([
   {
@@ -15,10 +16,16 @@ const router = createBrowserRouter([
     path: "/:pokeId",
     element: <PokeDetail />,
   },
+  {
+    path: "/team",
+    element: <Team />,
+  },
 ]);
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <PokemonProvider>
-    <RouterProvider router={router} />
+    <TeamProvider>
+      <RouterProvider router={router} />
+    </TeamProvider>
   </PokemonProvider>
 );

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,4 +1,5 @@
 import { useContext } from "react";
+import { Link } from "react-router-dom";
 import { PokeballIconSmall } from "../../assets/pokeball";
 import { Filters } from "../../components/Filters";
 import { Pagination } from "../../components/Pagination";
@@ -21,6 +22,9 @@ export const Home = () => {
           <PokeballIconSmall />
           <span>Pokédex</span>
         </div>
+        <Link to="/team" className={styles.teamLink}>
+          Mi Equipo
+        </Link>
       </header>
       <Filters />
       <PokemonList

--- a/src/pages/Home/styles.module.scss
+++ b/src/pages/Home/styles.module.scss
@@ -10,6 +10,7 @@
     align-items: center;
     justify-content: center;
     margin: 0 auto;
+    gap: 1rem;
 
     div {
       width: fit-content;
@@ -18,6 +19,11 @@
       align-items: center;
       justify-content: center;
       gap: 1rem;
+    }
+
+    .teamLink {
+      text-decoration: none;
+      color: inherit;
     }
 
     span {

--- a/src/pages/Team/index.tsx
+++ b/src/pages/Team/index.tsx
@@ -1,0 +1,50 @@
+import { useContext } from "react";
+import { Link } from "react-router-dom";
+import { PokeballIconSmall } from "../../assets/pokeball";
+import { Pagination } from "../../components/Pagination";
+import { TeamPokemonCard } from "../../components/TeamPokemonCard";
+import { TeamContext } from "../../context/TeamContext";
+import { usePagination } from "../../hooks/usePagination";
+
+import styles from "./styles.module.scss";
+
+export const Team = () => {
+  const { team } = useContext(TeamContext);
+  const { page, nextPage, previousPage, backToHome } = usePagination();
+
+  const perPage = 6;
+
+  return (
+    <div className={styles.team}>
+      <header>
+        <div onClick={backToHome} className={styles.homeLink}>
+          <PokeballIconSmall />
+          <span>Pokédex</span>
+        </div>
+        <Link to="/team" className={styles.current}>
+          Mi Equipo
+        </Link>
+      </header>
+      {team.length === 0 ? (
+        <p className={styles.empty}>No hay Pokémon en tu equipo.</p>
+      ) : (
+        <>
+          <div className={styles.list}>
+            {team
+              .slice((page - 1) * perPage, (page - 1) * perPage + perPage)
+              .map((url) => (
+                <TeamPokemonCard key={url} url={url} />
+              ))}
+          </div>
+          <Pagination
+            page={page}
+            perPage={perPage}
+            nextPage={nextPage}
+            previousPage={previousPage}
+            maxItems={team.length}
+          />
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/pages/Team/styles.module.scss
+++ b/src/pages/Team/styles.module.scss
@@ -1,0 +1,41 @@
+.team {
+  min-height: 100vh;
+  padding-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  header {
+    max-width: 650px;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem;
+
+    .homeLink {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      cursor: pointer;
+    }
+
+    .current {
+      font-weight: bold;
+      text-decoration: none;
+      color: inherit;
+    }
+  }
+
+  .empty {
+    margin-top: 2rem;
+  }
+
+  .list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,2 +1,3 @@
 export { Home } from "./Home";
 export { PokeDetail } from "./PokeDetail";
+export { Team } from './Team';


### PR DESCRIPTION
## Summary
- create a `TeamContext` for managing a list of Pokémon stored in `localStorage`
- add `TeamPokemonCard` component for removing Pokémon from the team
- add My Team page and routing
- show link to My Team on home page
- allow adding or removing a Pokémon from its detail view

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6840ccc847408325b949872e22c9b26a