### PR TITLE
Add in-memory pokemon cache

### DIFF
--- a/src/hooks/usePokemon.ts
+++ b/src/hooks/usePokemon.ts
@@ -2,24 +2,34 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 import { IPokemon } from "../interfaces/interfaces";
 
+// Simple in-memory cache to avoid unnecessary requests
+const pokemonCache = new Map<string, IPokemon>();
+
 export const usePokemon = (url?: string, id?: string) => {
   const [pokemon, setPokemon] = useState<null | undefined | IPokemon>();
 
   const fetchPokemon = async () => {
+    if (id && pokemonCache.has(id)) {
+      setPokemon(pokemonCache.get(id));
+      return;
+    }
+
     if (url) {
-      const { data }: any = await axios.get(url);
+      const { data }: { data: IPokemon } = await axios.get(url);
       setPokemon(data);
+      pokemonCache.set(data.id.toString(), data);
     } else if (id) {
-      const { data }: any = await axios.get(
+      const { data }: { data: IPokemon } = await axios.get(
         `https://pokeapi.co/api/v2/pokemon/${id}`
       );
       setPokemon(data);
+      pokemonCache.set(id, data);
     }
   };
 
   useEffect(() => {
     fetchPokemon();
-  }, []);
+  }, [url, id]);
 
   return { pokemon };
 };


### PR DESCRIPTION
## Summary
- cache pokemon info in a Map keyed by id inside `usePokemon`
- simplified logic: rely on provided id when available, no URL parsing needed

## Testing
- `yarn install` *(fails: tunneling socket could not be established)*
- `yarn build` *(fails: package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6840c761322c83258e32a606a568f0e7